### PR TITLE
fix: 🐛 Fixed issue where component name would get overwritten

### DIFF
--- a/src/cms/contexts/cmsContext/useCMSContext.tsx
+++ b/src/cms/contexts/cmsContext/useCMSContext.tsx
@@ -33,7 +33,7 @@ export const useCMS = () => {
    */
   const createComponent = (componentName: string) => {
     const component = components?.find(
-      (c: BlockType) => (c.name = componentName)
+      (c: BlockType) => c.name === componentName
     )
 
     if (!component) return undefined


### PR DESCRIPTION
I'm an idiot, but I can't believe that didn't error out at any point.